### PR TITLE
Update PrimeFactors.java

### DIFF
--- a/PrimeFactors.java
+++ b/PrimeFactors.java
@@ -28,7 +28,7 @@ public class PrimeFactors {
 			}
 			if(ile==1 && max_p_factor<i && zakres%i==0) max_p_factor = i; 
 			ile = 0L;
-		}
+		} //musiałem dodać jakąś zmianę żeby komentarz wystawić, nie umiałem inaczej
 		
 		return max_p_factor;
 	}


### PR DESCRIPTION
Myślę, że widze w czym rzecz z tym długim czasem wykonania. Potrzebujesz efektywniejszego sposobu wyznaczania liczby pierwszej niż przechodzenie po całym zakresie danej liczby w wewnętrznej pętli. Ja też kiedyś nie wiedziałem o tej właściwości i dlatego w takich momentach przydaje się np. baeldung. :) Zadałbym pytanie java find primes baeldung i spróbował wydzielić wyznaczanie liczby pierwszej do osobnej metody, tak żeby maxPrimeFactor rozwiązywał zadanie w jednej pętli. Daj znać w razie gdybyś miał problem, ale jak to rozwalisz to też daj znać.